### PR TITLE
feat: display median processing time over average

### DIFF
--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -90,7 +90,7 @@ export class HomeComponent implements OnInit {
 
     return <StatisticsCard>{
       header: `${Math.round(averageProcessingTime)} days`,
-      text: `average response time in past month`,
+      text: `median response time in past month`,
     };
   }
 

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -76,12 +76,17 @@ export class HomeComponent implements OnInit {
         ) < 30,
     );
 
-    let avg = 0;
+    // Find median time (avoid averages as sample space isn't large enough yet,
+    // values risk being inflated dramatically by a few outliers)
+    let days: number[] = [];
     for (const app of pastMonthApplications) {
-      avg += app.days;
+      days.push(app.days);
     }
 
-    const averageProcessingTime: number = avg / pastMonthApplications.length;
+    days = [...days].sort((a, b) => a - b);
+    const half = Math.floor(days.length / 2);
+    const averageProcessingTime: number =
+      days.length % 2 ? days[half] : (days[half - 1] + days[half]) / 2;
 
     return <StatisticsCard>{
       header: `${Math.round(averageProcessingTime)} days`,


### PR DESCRIPTION
At the moment, the available data for processing times is quite small (<50 samples). Displaying the average processing time risks skewing the data in either direction (overly positive or pessimistic estimates) due to the presence of a few outliers which took very long/too little time to process. Until we gain more data, it would be best to display the median processing time instead.